### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/mp3TF/keywords.txt
+++ b/mp3TF/keywords.txt
@@ -6,49 +6,49 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-mp3TF			KEYWORD1
+mp3TF	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init			KEYWORD2
-playNext		KEYWORD2
-playPrev		KEYWORD2
+init	KEYWORD2
+playNext	KEYWORD2
+playPrev	KEYWORD2
 playTrackPhisical	KEYWORD2
 playRepeatSingle	KEYWORD2
-playFolder		KEYWORD2
-playFolder2		KEYWORD2
-play			KEYWORD2
-pause			KEYWORD2
-stop			KEYWORD2
-playAllRepeat		KEYWORD2
-playMP3Folder		KEYWORD2
+playFolder	KEYWORD2
+playFolder2	KEYWORD2
+play	KEYWORD2
+pause	KEYWORD2
+stop	KEYWORD2
+playAllRepeat	KEYWORD2
+playMP3Folder	KEYWORD2
 playFolderRepeat	KEYWORD2
-playRandom		KEYWORD2
-repeatCurrent		KEYWORD2
+playRandom	KEYWORD2
+repeatCurrent	KEYWORD2
 
-volumeInc		KEYWORD2
-volumeDec		KEYWORD2
-volumeSet		KEYWORD2
+volumeInc	KEYWORD2
+volumeDec	KEYWORD2
+volumeSet	KEYWORD2
 
-setEQ			KEYWORD2
+setEQ	KEYWORD2
 setAudioAmplifier	KEYWORD2
 
-Sleep			KEYWORD2
-Reset			KEYWORD2
-setInterCut		KEYWORD2
-stopInterCut		KEYWORD2
-useDAC			KEYWORD2
+Sleep	KEYWORD2
+Reset	KEYWORD2
+setInterCut	KEYWORD2
+stopInterCut	KEYWORD2
+useDAC	KEYWORD2
 
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-MP3_EQ_NORMAL		LITERAL1
-MP3_EQ_POP 		LITERAL1
-MP3_EQ_ROCK 		LITERAL1
-MP3_EQ_JAZZ 		LITERAL1
-MP3_EQ_CLASSIC 		LITERAL1
-MP3_EQ_BASS 		LITERAL1
+MP3_EQ_NORMAL	LITERAL1
+MP3_EQ_POP	LITERAL1
+MP3_EQ_ROCK	LITERAL1
+MP3_EQ_JAZZ	LITERAL1
+MP3_EQ_CLASSIC	LITERAL1
+MP3_EQ_BASS	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords